### PR TITLE
Require main function in grammar

### DIFF
--- a/Grammar.cup
+++ b/Grammar.cup
@@ -16,7 +16,7 @@ terminal If, Elif, Else, While, Input, For, In, Def, From, Import, Punto, Corche
          NumeroEntero, NumeroDecimal, Int, Float, Const, Bool, String, Main, Cadena, Char, Identificador,Break, Error;
 
 /* ─────────────  NO TERMINALES  ───────────── */
-non terminal INICIO, BLOQUE, DECLARACIONES, FUNCIONES, FUNCION, PARAMS, SENTENCIAS, SENTENCIA, ASIGNACION, 
+non terminal PROGRAMA, OPC_DECL, OPC_FUNCIONES, DECLARACIONES, FUNCION_PRINCIPAL, FUNCIONES, FUNCION, PARAMS, SENTENCIAS, SENTENCIA, ASIGNACION,
              EXPRESION, LLAMADA_FUNCION, IF_STATEMENT, ELIF_BLOQUES, ELSE_BLOQUE, DECLARACION_TIPADA,
              WHILE_LOOP, FOR_LOOP, PRINT_STMT, VALOR, IMPORT_STMT, LISTA_VALORES ;
 
@@ -28,18 +28,18 @@ precedence left Multiplicacion, Division, Modulo;
 precedence right Potencia;
 
 /* ─────────────  INICIO  ───────────── */
-start with INICIO;
+start with PROGRAMA;
 
 /* ─────────────  PRODUCCIONES  ───────────── */
 
 /* 1. Programa: declaraciones globales + funciones */
-INICIO ::= BLOQUE
-         | INICIO BLOQUE;
+PROGRAMA ::= OPC_DECL FUNCION_PRINCIPAL OPC_FUNCIONES;
 
-BLOQUE ::= FUNCION
-         | ASIGNACION PuntoComa
-         | DECLARACION_TIPADA PuntoComa
-         | IMPORT_STMT PuntoComa;
+OPC_DECL ::= DECLARACIONES
+           | /* vacío */;
+
+OPC_FUNCIONES ::= FUNCIONES
+                | /* vacío */;
 
 
 /* 2. Declaraciones globales */
@@ -58,9 +58,11 @@ FUNCIONES ::= FUNCION
             | FUNCIONES FUNCION;
 
 
-/* 5. Definición de función */
-FUNCION ::= Def Identificador Parentesis_a PARAMS Parentesis_c Llave_a SENTENCIAS Llave_c
-            |Def Main Parentesis_a PARAMS Parentesis_c Llave_a SENTENCIAS Llave_c;
+/* 5. Definición de función principal */
+FUNCION_PRINCIPAL ::= Def Main Parentesis_a PARAMS Parentesis_c Llave_a SENTENCIAS Llave_c;
+
+/* 6. Definición de función regular */
+FUNCION ::= Def Identificador Parentesis_a PARAMS Parentesis_c Llave_a SENTENCIAS Llave_c;
 
 
 /* 6. Parámetros */

--- a/SemanticAnalyzer.java
+++ b/SemanticAnalyzer.java
@@ -75,9 +75,25 @@ public class SemanticAnalyzer {
         SymbolTable.clear();
         LexerCup lexer = new LexerCup(new StringReader(code));
         Symbol tok;
+        boolean inMain = false;
+        int braceDepth = 0;
         while(true) {
             tok = lexer.next_token();
             if(tok.sym == sym.EOF) break;
+
+            if(tok.sym == sym.Main) {
+                inMain = true;
+                braceDepth = 0;
+                continue;
+            }
+            if(inMain && tok.sym == sym.Llave_a) {
+                braceDepth++;
+            } else if(inMain && tok.sym == sym.Llave_c) {
+                braceDepth--;
+                if(braceDepth <= 0) {
+                    inMain = false;
+                }
+            }
             if(tok.sym == sym.Const) {
                 Symbol typeTok = lexer.next_token();
                 if(!isType(typeTok.sym)) continue; // invalid
@@ -89,7 +105,7 @@ public class SemanticAnalyzer {
                 if(opTok.sym != sym.Op_asignacion) continue;
                 Symbol firstExpr = lexer.next_token();
                 Expression expr = readExpression(lexer, firstExpr);
-                SymbolTable.declare(nombre, tipoDato, expr.valor, true, "global");
+                SymbolTable.declare(nombre, tipoDato, expr.valor, true, inMain ? "main" : "global");
                 if(!expr.tipo.equals("desconocido") && !expr.tipo.equals(tipoDato)) {
                     SymbolTable.addError("Error: tipo incompatible para " + nombre);
                 }
@@ -102,7 +118,7 @@ public class SemanticAnalyzer {
                 if(opTok.sym != sym.Op_asignacion) continue;
                 Symbol firstExpr = lexer.next_token();
                 Expression expr = readExpression(lexer, firstExpr);
-                SymbolTable.declare(nombre, tipoDato, expr.valor, false, "global");
+                SymbolTable.declare(nombre, tipoDato, expr.valor, false, inMain ? "main" : "global");
                 if(!expr.tipo.equals("desconocido") && !expr.tipo.equals(tipoDato)) {
                     SymbolTable.addError("Error: tipo incompatible para " + nombre);
                 }


### PR DESCRIPTION
## Summary
- enforce presence of a `main` function in grammar
- add helper productions for optional globals and other functions
- update semantic analyzer to track declarations inside `main`

## Testing
- `javac -cp java-cup-11a.jar:. -Xlint:none *.java` *(fails: package JFlex does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6870322b7128832eae01316a93248744