### PR TITLE
Support uninitialized variable declarations

### DIFF
--- a/Grammar.cup
+++ b/Grammar.cup
@@ -18,7 +18,7 @@ terminal If, Elif, Else, While, Input, For, In, Def, From, Import, Punto, Corche
 /* ─────────────  NO TERMINALES  ───────────── */
 non terminal PROGRAMA, OPC_DECL, OPC_FUNCIONES, DECLARACIONES, FUNCION_PRINCIPAL, FUNCIONES, FUNCION, PARAMS, SENTENCIAS, SENTENCIA, ASIGNACION,
              EXPRESION, LLAMADA_FUNCION, IF_STATEMENT, ELIF_BLOQUES, ELSE_BLOQUE, DECLARACION_TIPADA,
-             WHILE_LOOP, FOR_LOOP, PRINT_STMT, VALOR, IMPORT_STMT, LISTA_VALORES ;
+             WHILE_LOOP, FOR_LOOP, PRINT_STMT, VALOR, IMPORT_STMT, LISTA_VALORES, OPC_INIT ;
 
 /* ─────────────  PRECEDENCIAS  ───────────── */
 precedence left Op_logico;
@@ -86,14 +86,17 @@ SENTENCIA ::= ASIGNACION       PuntoComa
             | Break PuntoComa;
 
 
-DECLARACION_TIPADA ::= Int Identificador Op_asignacion EXPRESION
-                     | Float Identificador Op_asignacion EXPRESION
-                     | Bool Identificador Op_asignacion EXPRESION
-                     | String Identificador Op_asignacion EXPRESION
+DECLARACION_TIPADA ::= Int Identificador OPC_INIT
+                     | Float Identificador OPC_INIT
+                     | Bool Identificador OPC_INIT
+                     | String Identificador OPC_INIT
                      | Const Int Identificador Op_asignacion EXPRESION
                      | Const Float Identificador Op_asignacion EXPRESION
                      | Const Bool Identificador Op_asignacion EXPRESION
                      | Const String Identificador Op_asignacion EXPRESION ;
+
+OPC_INIT ::= Op_asignacion EXPRESION
+           | /* vacío */;
 
 
 /* 9. Asignación */

--- a/SemanticAnalyzer.java
+++ b/SemanticAnalyzer.java
@@ -114,13 +114,18 @@ public class SemanticAnalyzer {
                 Symbol idTok = lexer.next_token();
                 if(idTok.sym != sym.Identificador) continue;
                 String nombre = idTok.value.toString();
-                Symbol opTok = lexer.next_token();
-                if(opTok.sym != sym.Op_asignacion) continue;
-                Symbol firstExpr = lexer.next_token();
-                Expression expr = readExpression(lexer, firstExpr);
-                SymbolTable.declare(nombre, tipoDato, expr.valor, false, inMain ? "main" : "global");
-                if(!expr.tipo.equals("desconocido") && !expr.tipo.equals(tipoDato)) {
-                    SymbolTable.addError("Error: tipo incompatible para " + nombre);
+                Symbol nextTok = lexer.next_token();
+                if(nextTok.sym == sym.Op_asignacion) {
+                    Symbol firstExpr = lexer.next_token();
+                    Expression expr = readExpression(lexer, firstExpr);
+                    SymbolTable.declare(nombre, tipoDato, expr.valor, false, inMain ? "main" : "global");
+                    if(!expr.tipo.equals("desconocido") && !expr.tipo.equals(tipoDato)) {
+                        SymbolTable.addError("Error: tipo incompatible para " + nombre);
+                    }
+                } else if(nextTok.sym == sym.PuntoComa) {
+                    SymbolTable.declare(nombre, tipoDato, "", false, inMain ? "main" : "global");
+                } else {
+                    // token unexpected, skip until semicolon
                 }
             } else if(tok.sym == sym.Identificador) {
                 String nombre = tok.value.toString();


### PR DESCRIPTION
## Summary
- extend the grammar with `OPC_INIT` for optional initialization
- allow variable declarations without assignment in the semantic analyzer

## Testing
- `javac *.java` *(fails: package `java_cup.runtime` missing)*

------
https://chatgpt.com/codex/tasks/task_e_687043eaa1ec832e9b641b3ec343796d