### PR TITLE
Add operations sequence to symbol table

### DIFF
--- a/SymbolEntry.java
+++ b/SymbolEntry.java
@@ -7,6 +7,7 @@ public class SymbolEntry {
     public String valor;
     public String alcance;
     public boolean esConstante;
+    public java.util.List<String> operaciones;
 
     public SymbolEntry(String tipo, String nombre, String tipoDato, String valor, String alcance, boolean esConstante) {
         this.tipo = tipo;
@@ -15,5 +16,6 @@ public class SymbolEntry {
         this.valor = valor;
         this.alcance = alcance;
         this.esConstante = esConstante;
+        this.operaciones = new java.util.ArrayList<>();
     }
 }

--- a/SymbolTable.java
+++ b/SymbolTable.java
@@ -6,6 +6,58 @@ public class SymbolTable {
     private static Map<String, SymbolEntry> tabla = new LinkedHashMap<>();
     private static List<String> errores = new ArrayList<>();
 
+    private static Double numericValue(String nombre) {
+        SymbolEntry e = tabla.get(nombre);
+        if(e == null) return null;
+        try {
+            return Double.parseDouble(e.valor);
+        } catch(NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    private static class Evaluator {
+        private final String[] tokens;
+        private int pos = 0;
+        Evaluator(String expr) { this.tokens = expr.trim().isEmpty() ? new String[0] : expr.trim().split("\\s+"); }
+
+        double parseExpression() { double val = parseTerm();
+            while(pos < tokens.length) {
+                String op = tokens[pos];
+                if(op.equals("+") || op.equals("-")) { pos++; double t = parseTerm(); val = op.equals("+") ? val + t : val - t; }
+                else break;
+            }
+            return val; }
+
+        double parseTerm() { double val = parseFactor();
+            while(pos < tokens.length) {
+                String op = tokens[pos];
+                if(op.equals("*") || op.equals("/")) { pos++; double f = parseFactor(); val = op.equals("*") ? val * f : val / f; }
+                else break;
+            }
+            return val; }
+
+        double parseFactor() { String tok = tokens[pos];
+            if(tok.equals("(")) { pos++; double val = parseExpression(); if(pos < tokens.length && tokens[pos].equals(")")) pos++; return val; }
+            pos++; return parseNumberOrVar(tok); }
+
+        double parseNumberOrVar(String tok) {
+            try { return Double.parseDouble(tok); } catch(NumberFormatException ex) {
+                Double v = numericValue(tok);
+                if(v != null) return v;
+                throw new RuntimeException("Invalid token " + tok);
+            }}
+    }
+
+    private static Double evalNumericExpr(String expr) {
+        try {
+            Evaluator ev = new Evaluator(expr);
+            return ev.parseExpression();
+        } catch(Exception ex) {
+            return null;
+        }
+    }
+
     public static void clear() {
         tabla.clear();
         errores.clear();
@@ -21,7 +73,20 @@ public class SymbolTable {
             return;
         }
         String tipo = constante ? "constante" : "variable";
-        tabla.put(nombre, new SymbolEntry(tipo, nombre, tipoDato, valor, alcance, constante));
+        SymbolEntry e = new SymbolEntry(tipo, nombre, tipoDato, valor, alcance, constante);
+        e.operaciones.add("Declaraci\u00f3n");
+        if(valor != null && !valor.isEmpty()) {
+            String op = "Asignaci\u00f3n: " + valor;
+            if(tipoDato.equals("int") || tipoDato.equals("float")) {
+                Double res = evalNumericExpr(valor);
+                if(res != null) {
+                    e.valor = res % 1 == 0 ? Integer.toString(res.intValue()) : res.toString();
+                    op += " = " + e.valor;
+                }
+            }
+            e.operaciones.add(op);
+        }
+        tabla.put(nombre, e);
     }
 
     public static void assign(String nombre, String tipoDato, String valor) {
@@ -37,7 +102,19 @@ public class SymbolTable {
         if(tipoDato != null && !tipoDato.equals("desconocido") && !e.tipoDato.equals(tipoDato)) {
             errores.add("Error: tipo incompatible para " + nombre + ". Se esperaba " + e.tipoDato + " y se obtuvo " + tipoDato);
         }
-        e.valor = valor;
+        String op = "Asignaci\u00f3n: " + valor;
+        if(e.tipoDato.equals("int") || e.tipoDato.equals("float")) {
+            Double res = evalNumericExpr(valor);
+            if(res != null) {
+                e.valor = res % 1 == 0 ? Integer.toString(res.intValue()) : res.toString();
+                op += " = " + e.valor;
+            } else {
+                e.valor = valor;
+            }
+        } else {
+            e.valor = valor;
+        }
+        e.operaciones.add(op);
     }
 
     public static String getType(String nombre) {
@@ -56,10 +133,11 @@ public class SymbolTable {
     public static String report() {
         StringBuilder sb = new StringBuilder();
         sb.append("Tabla de S\u00edmbolos:\n");
-        sb.append("Tipo\tNombre\tTipoDato\tValor\tAlcance\n");
+        sb.append("Tipo\tNombre\tTipoDato\tValor\tAlcance\tSecuencia de Operaciones\n");
         for(SymbolEntry e : tabla.values()) {
             sb.append(e.tipo).append('\t').append(e.nombre).append('\t').append(e.tipoDato)
-              .append('\t').append(e.valor).append('\t').append(e.alcance).append('\n');
+              .append('\t').append(e.valor).append('\t').append(e.alcance).append('\t');
+            sb.append(String.join(", ", e.operaciones)).append('\n');
         }
         if(!errores.isEmpty()) {
             sb.append("\nErrores Sem\u00e1nticos:\n");


### PR DESCRIPTION
## Summary
- store a list of performed operations in `SymbolEntry`
- extend `SymbolTable` with an expression evaluator for numeric assignments
- record declarations and assignments in the new `operaciones` field
- show operations in the symbol table report

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68704c77f51c832e9bd22aa7c329e406