### PR TITLE
Fix assignment into table when type mismatch

### DIFF
--- a/SemanticAnalyzer.java
+++ b/SemanticAnalyzer.java
@@ -114,7 +114,7 @@ public class SemanticAnalyzer {
                 if(opTok.sym != sym.Op_asignacion) continue;
                 Symbol firstExpr = lexer.next_token();
                 Expression expr = readExpression(lexer, firstExpr);
-                SymbolTable.declare(nombre, tipoDato, expr.valor, true, inMain ? "main" : "global");
+                SymbolTable.declare(nombre, tipoDato, expr.valor, expr.tipo, true, inMain ? "main" : "global");
                 if(!expr.tipo.equals("desconocido") && !expr.tipo.equals(tipoDato)) {
                     SymbolTable.addError("Error: tipo incompatible para " + nombre);
                 }
@@ -127,12 +127,12 @@ public class SemanticAnalyzer {
                 if(nextTok.sym == sym.Op_asignacion) {
                     Symbol firstExpr = lexer.next_token();
                     Expression expr = readExpression(lexer, firstExpr);
-                    SymbolTable.declare(nombre, tipoDato, expr.valor, false, inMain ? "main" : "global");
+                    SymbolTable.declare(nombre, tipoDato, expr.valor, expr.tipo, false, inMain ? "main" : "global");
                     if(!expr.tipo.equals("desconocido") && !expr.tipo.equals(tipoDato)) {
                         SymbolTable.addError("Error: tipo incompatible para " + nombre);
                     }
                 } else if(nextTok.sym == sym.PuntoComa) {
-                    SymbolTable.declare(nombre, tipoDato, "", false, inMain ? "main" : "global");
+                    SymbolTable.declare(nombre, tipoDato, "", null, false, inMain ? "main" : "global");
                 } else {
                     // token unexpected, skip until semicolon
                 }

--- a/SymbolTable.java
+++ b/SymbolTable.java
@@ -107,16 +107,20 @@ public class SymbolTable {
         errores.add(e);
     }
 
-    public static void declare(String nombre, String tipoDato, String valor, boolean constante, String alcance) {
+    public static void declare(String nombre, String tipoDato, String valor, String tipoValor, boolean constante, String alcance) {
         if(tabla.containsKey(nombre)) {
             errores.add("Error: doble declaraci\u00f3n de " + nombre);
             return;
         }
         String tipo = constante ? "constante" : "variable";
-        SymbolEntry e = new SymbolEntry(tipo, nombre, tipoDato, valor, alcance, constante);
+        SymbolEntry e = new SymbolEntry(tipo, nombre, tipoDato, "", alcance, constante);
         e.operaciones.add("Declaraci\u00f3n");
         boolean hayError = false;
+        boolean asignar = true;
         if(valor != null && !valor.isEmpty()) {
+            if(tipoValor != null && !tipoValor.equals("desconocido") && !tipoDato.equals(tipoValor)) {
+                asignar = false;
+            }
             String op = "Asignaci\u00f3n: " + valor;
             boolean simpleConst = isSimpleConstant(valor);
             if(tipoDato.equals("int") || tipoDato.equals("float")) {
@@ -124,7 +128,7 @@ public class SymbolTable {
                     errores.add("Error: tipo incompatible en operaci\u00f3n para " + nombre);
                     hayError = true;
                 }
-                if(!hayError) {
+                if(!hayError && asignar) {
                     Double res = evalNumericExpr(valor);
                     if(res != null) {
                         e.valor = res % 1 == 0 ? Integer.toString(res.intValue()) : res.toString();
@@ -132,9 +136,9 @@ public class SymbolTable {
                     }
                 }
                 } else {
-                if(!hayError) e.valor = valor;
+                if(!hayError && asignar) e.valor = valor;
             }
-            if(!hayError) e.operaciones.add(op);
+            if(!hayError && asignar) e.operaciones.add(op);
         }
         if(!hayError)
             tabla.put(nombre, e);


### PR DESCRIPTION
## Summary
- ensure declarations only store initial value when types match
- update SemanticAnalyzer to pass expression type to declaration

## Testing
- `javac -cp .:java-cup-11a.jar SemanticAnalyzer.java SymbolEntry.java SymbolTable.java LexerCup.java Tokens.java sym.java FrmPrincipal.java Lexer.java Syntactic.java`

------
https://chatgpt.com/codex/tasks/task_e_6871105d3ff0832ebaf0bad7ada912d7