### PR TITLE
Fix boolean declaration logic

### DIFF
--- a/SymbolTable.java
+++ b/SymbolTable.java
@@ -118,7 +118,8 @@ public class SymbolTable {
         boolean hayError = false;
         boolean asignar = true;
         if(valor != null && !valor.isEmpty()) {
-            if(tipoValor != null && !tipoValor.equals("desconocido") && !tipoDato.equals(tipoValor)) {
+            if(tipoValor == null || tipoValor.equals("desconocido") || !tipoDato.equals(tipoValor)) {
+                hayError = true;
                 asignar = false;
             }
             String op = "Asignaci\u00f3n: " + valor;


### PR DESCRIPTION
## Summary
- avoid storing declarations when the initializer type does not match

## Testing
- `javac -d . -cp .:java-cup-11a.jar SemanticAnalyzer.java SymbolTable.java SymbolEntry.java LexerCup.java sym.java Tokens.java`
- `javac -cp .:java-cup-11a.jar TestSemantic.java`
- `java -cp .:java-cup-11a.jar TestSemantic`
- `javac -cp .:java-cup-11a.jar TestSemantic2.java`
- `java -cp .:java-cup-11a.jar TestSemantic2`


------
https://chatgpt.com/codex/tasks/task_e_68743257f63c832e9b75e3398ca193e4