### PR TITLE
Improve semantic error reporting

### DIFF
--- a/FrmPrincipal.java
+++ b/FrmPrincipal.java
@@ -841,7 +841,11 @@ case ARROW:
             s.parse();
             String reporte = SemanticAnalyzer.analyze(ST);
             txtAnalizarSin.setText("An\u00e1lisis Sintáctico Realizado Correctamente\n" + reporte);
-            txtAnalizarSin.setForeground(new Color(65, 84, 100));
+            if(reporte.contains("Errores Sem\u00e1nticos")) {
+                txtAnalizarSin.setForeground(Color.RED);
+            } else {
+                txtAnalizarSin.setForeground(Color.GREEN);
+            }
             limpiarResaltado();
         } catch (Exception ex) {
             Symbol sym = s.getS();

--- a/SemanticAnalyzer.java
+++ b/SemanticAnalyzer.java
@@ -31,7 +31,7 @@ public class SemanticAnalyzer {
         if(tok.sym == sym.Identificador) {
             String t = SymbolTable.getType(tok.value.toString());
             if(t == null) {
-                SymbolTable.addError("Error: variable no declarada " + tok.value.toString());
+                SymbolTable.addError("Error: variable no declarada " + tok.value.toString(), tok.left + 1);
                 return "desconocido";
             }
             return t;
@@ -116,9 +116,9 @@ public class SemanticAnalyzer {
                 if(opTok.sym != sym.Op_asignacion) continue;
                 Symbol firstExpr = lexer.next_token();
                 Expression expr = readExpression(lexer, firstExpr);
-                SymbolTable.declare(nombre, tipoDato, expr.valor, expr.tipo, true, inMain ? "main" : "global");
+                SymbolTable.declare(nombre, tipoDato, expr.valor, expr.tipo, true, inMain ? "main" : "global", tok.left + 1);
                 if(!expr.tipo.equals("desconocido") && !expr.tipo.equals(tipoDato)) {
-                    SymbolTable.addError("Error: tipo incompatible para " + nombre);
+                    SymbolTable.addError("Error: tipo incompatible para " + nombre, tok.left + 1);
                 }
             } else if(isType(tok.sym)) {
                 String tipoDato = ((String)tok.value).toLowerCase();
@@ -129,12 +129,12 @@ public class SemanticAnalyzer {
                 if(nextTok.sym == sym.Op_asignacion) {
                     Symbol firstExpr = lexer.next_token();
                      Expression expr = readExpression(lexer, firstExpr);
-                    SymbolTable.declare(nombre, tipoDato, expr.valor, expr.tipo, false, inMain ? "main" : "global");
+                    SymbolTable.declare(nombre, tipoDato, expr.valor, expr.tipo, false, inMain ? "main" : "global", tok.left + 1);
                     if(!expr.tipo.equals("desconocido") && !expr.tipo.equals(tipoDato)) {
-                        SymbolTable.addError("Error: tipo incompatible para " + nombre);
+                        SymbolTable.addError("Error: tipo incompatible para " + nombre, tok.left + 1);
                     }
                 } else if(nextTok.sym == sym.PuntoComa) {
-                    SymbolTable.declare(nombre, tipoDato, "", null, false, inMain ? "main" : "global");
+                    SymbolTable.declare(nombre, tipoDato, "", null, false, inMain ? "main" : "global", tok.left + 1);
                 } else {
                     // token unexpected, skip until semicolon
                 }
@@ -144,7 +144,7 @@ public class SemanticAnalyzer {
                 if(opTok.sym != sym.Op_asignacion) continue;
                 Symbol firstExpr = lexer.next_token();
                 Expression expr = readExpression(lexer, firstExpr);
-                SymbolTable.assign(nombre, expr.tipo, expr.valor);
+                SymbolTable.assign(nombre, expr.tipo, expr.valor, tok.left + 1);
             }
         }
         return SymbolTable.report();

--- a/SymbolTable.java
+++ b/SymbolTable.java
@@ -138,14 +138,18 @@ public class SymbolTable {
         currentScope = "global";
     }
 
+    public static void addError(String e, int linea) {
+        errores.add("L\u00ednea " + linea + ": " + e);
+    }
+
     public static void addError(String e) {
         errores.add(e);
     }
 
-    public static void declare(String nombre, String tipoDato, String valor, String tipoValor, boolean constante, String alcance) {
+    public static void declare(String nombre, String tipoDato, String valor, String tipoValor, boolean constante, String alcance, int linea) {
         String key = makeKey(nombre, alcance);
         if(tabla.containsKey(key)) {
-            errores.add("Error: doble declaraci\u00f3n de " + nombre);
+            addError("Error: doble declaraci\u00f3n de " + nombre, linea);
             return;
         }
         String tipo = constante ? "constante" : "variable";
@@ -162,7 +166,7 @@ public class SymbolTable {
             boolean simpleConst = isSimpleConstant(valor);
             if(tipoDato.equals("int") || tipoDato.equals("float")) {
                 if(numericExprHasInvalidTokens(valor)) {
-                    errores.add("Error: tipo incompatible en operaci\u00f3n para " + nombre);
+                    addError("Error: tipo incompatible en operaci\u00f3n para " + nombre, linea);
                     hayError = true;
                 }
                 if(!hayError && asignar) {
@@ -181,26 +185,26 @@ public class SymbolTable {
             tabla.put(key, e);
     }
 
-     public static void assign(String nombre, String tipoDato, String valor) {
+    public static void assign(String nombre, String tipoDato, String valor, int linea) {
          SymbolEntry e = findEntry(nombre);
         if(e == null) {
-            errores.add("Error: variable no declarada " + nombre);
+            addError("Error: variable no declarada " + nombre, linea);
             return;
         }
         if(e.esConstante) {
-            errores.add("Error: no se puede modificar la constante " + nombre);
+            addError("Error: no se puede modificar la constante " + nombre, linea);
             return;
         }
         boolean hayError = false;
         if(tipoDato != null && !tipoDato.equals("desconocido") && !e.tipoDato.equals(tipoDato)) {
-            errores.add("Error: tipo incompatible para " + nombre + ". Se esperaba " + e.tipoDato + " y se obtuvo " + tipoDato);
+            addError("Error: tipo incompatible para " + nombre + ". Se esperaba " + e.tipoDato + " y se obtuvo " + tipoDato, linea);
             hayError = true;
         }
         String op = "Asignaci\u00f3n: " + valor;
         boolean simpleConst = isSimpleConstant(valor);
         if(e.tipoDato.equals("int") || e.tipoDato.equals("float")) {
             if(numericExprHasInvalidTokens(valor)) {
-                errores.add("Error: tipo incompatible en operaci\u00f3n para " + nombre);
+                addError("Error: tipo incompatible en operaci\u00f3n para " + nombre, linea);
                 hayError = true;
             }
             if(!hayError) {


### PR DESCRIPTION
## Summary
- show line numbers for semantic errors in `SymbolTable`
- highlight success messages in green in `FrmPrincipal`
- propagate line info in `SemanticAnalyzer`

## Testing
- `javac -classpath .:java-cup-11a.jar FrmPrincipal.java SemanticAnalyzer.java SymbolEntry.java SymbolTable.java Lexer.java LexerCup.java Syntactic.java Tokens.java sym.java`

------
https://chatgpt.com/codex/tasks/task_e_6875a483ba34832ebd1642665c30a9d8