### PR TITLE
Add array declarations and indexing

### DIFF
--- a/Grammar.cup
+++ b/Grammar.cup
@@ -18,7 +18,7 @@ terminal If, Elif, Else, While, Input, For, In, Def, From, Import, Punto, Corche
 /* ─────────────  NO TERMINALES  ───────────── */
 non terminal PROGRAMA, OPC_DECL, OPC_FUNCIONES, DECLARACIONES, FUNCION_PRINCIPAL, FUNCIONES, FUNCION, PARAMS, SENTENCIAS, SENTENCIA, ASIGNACION,
              EXPRESION, LLAMADA_FUNCION, IF_STATEMENT, ELIF_BLOQUES, ELSE_BLOQUE, DECLARACION_TIPADA,
-             WHILE_LOOP, FOR_LOOP, PRINT_STMT, VALOR, IMPORT_STMT, LISTA_VALORES, OPC_INIT ;
+             WHILE_LOOP, FOR_LOOP, PRINT_STMT, VALOR, IMPORT_STMT, LISTA_VALORES, OPC_INIT, OPC_INIT_ARRAY ;
 
 /* ─────────────  PRECEDENCIAS  ───────────── */
 precedence left Op_logico;
@@ -87,6 +87,7 @@ SENTENCIA ::= ASIGNACION       PuntoComa
 
 
 DECLARACION_TIPADA ::= Int Identificador OPC_INIT
+                     | Int Identificador Corchete_a NumeroEntero Corchete_c OPC_INIT_ARRAY
                      | Float Identificador OPC_INIT
                      | Bool Identificador OPC_INIT
                      | String Identificador OPC_INIT
@@ -103,9 +104,13 @@ DECLARACION_TIPADA ::= Int Identificador OPC_INIT
 OPC_INIT ::= Op_asignacion EXPRESION
            | /* vacío */;
 
+OPC_INIT_ARRAY ::= Op_asignacion Corchete_a LISTA_VALORES Corchete_c
+                 | /* vacío */;
+
 
 /* 9. Asignación */
-ASIGNACION ::= Identificador Op_asignacion EXPRESION ;
+ASIGNACION ::= Identificador Op_asignacion EXPRESION
+             | Identificador Corchete_a EXPRESION Corchete_c Op_asignacion EXPRESION ;
 
 /* 10. Llamada a función */
 LLAMADA_FUNCION ::= Identificador Parentesis_a PARAMS Parentesis_c ;


### PR DESCRIPTION
## Summary
- add syntax rules to allow array declarations
- add optional array initializer and indexing assignment

## Testing
- `javac -cp java-cup-11a.jar LexerCup.java FrmPrincipal.java Lexer.java SemanticAnalyzer.java SymbolEntry.java SymbolTable.java Syntactic.java Tokens.java sym.java`


------
https://chatgpt.com/codex/tasks/task_e_687838e8ce60832e9f7302389b1c042e