### PR TITLE
Add basic semantic analysis for arrays

### DIFF
--- a/SymbolEntry.java
+++ b/SymbolEntry.java
@@ -17,6 +17,8 @@ public class SymbolEntry {
     public String valor;
     public String alcance;
     public boolean esConstante;
+    public boolean esArreglo;
+    public int tamano;
     public java.util.List<String> operaciones;
 
     public SymbolEntry(String tipo, String nombre, String tipoDato, String valor, String alcance, boolean esConstante) {
@@ -26,6 +28,15 @@ public class SymbolEntry {
         this.valor = valor;
         this.alcance = alcance;
         this.esConstante = esConstante;
+        this.esArreglo = false;
+        this.tamano = 0;
         this.operaciones = new java.util.ArrayList<>();
+    }
+
+    public SymbolEntry(String tipo, String nombre, String tipoDato, String valor, String alcance,
+                        boolean esConstante, boolean esArreglo, int tamano) {
+        this(tipo, nombre, tipoDato, valor, alcance, esConstante);
+        this.esArreglo = esArreglo;
+        this.tamano = tamano;
     }
 }


### PR DESCRIPTION
## Summary
- extend `SymbolEntry` to track arrays
- add array declaration and element assignment helpers in `SymbolTable`
- include array size column in semantic report
- support array declarations and assignments in `SemanticAnalyzer`
- allow expression parsing with custom stop symbols

## Testing
- `javac -d . -cp java-cup-11a.jar @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_68783b5806cc832ea4c99209d5ab0270